### PR TITLE
NavigationAware updates

### DIFF
--- a/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
+++ b/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
@@ -44,31 +44,40 @@ namespace Prism.Navigation
             if( s_popupStack.Count == 0 ) return;
 
             var page = s_popupStack.Last();
-            HandleINavigationAware( page, parameters, navigatedTo: false );
+            HandleINavigatedAware( page, parameters, navigatedTo: false );
 
             await PopupNavigation.PopAsync( animate );
 
             Page currentPage = s_popupStack.LastOrDefault();
             if( currentPage == null ) currentPage = GetCurrentPage();
 
-            HandleINavigationAware( currentPage, parameters, navigatedTo: true );
+            HandleINavigatedAware( currentPage, parameters, navigatedTo: true );
         }
 
         public static async Task PushPopupPageAsync( this INavigationService navigationService, string name, NavigationParameters parameters = null, bool animated = true )
         {
             var page = CreatePopupPageByName( name );
             ViewModelLocator.SetAutowireViewModel( page, ViewModelLocator.GetAutowireViewModel( page ) ?? true );
+            HandleINavigatingAware( page, parameters );
             await PopupNavigation.PushAsync( page, animated );
-            HandleINavigationAware( page, parameters, navigatedTo: true );
+            HandleINavigatedAware( page, parameters, navigatedTo: true );
         }
 
         public static Task PushPopupPageAsync( this INavigationService navigationService, string name, string key, object param, bool animated = true ) =>
             navigationService.PushPopupPageAsync( name, GetNavigationParameters( key, param ), animated );
 
-        private static void HandleINavigationAware( Page page, NavigationParameters parameters, bool navigatedTo )
+        private static void HandleINavigatingAware( PopupPage page, NavigationParameters parameters )
+        {
+            //TODO: This will need to be updated to INavigatingAware once Pre2 is released
+            ( page as INavigationAware )?.OnNavigatingTo( parameters );
+            ( page?.BindingContext as INavigationAware )?.OnNavigatingTo( parameters );
+        }
+
+        private static void HandleINavigatedAware( Page page, NavigationParameters parameters, bool navigatedTo )
         {
             if( page == null ) return;
 
+            //TODO: Change this to INavigatedAware once pre2 is released
             var pageAware = page as INavigationAware;
             var contextAware = page.BindingContext as INavigationAware;
 

--- a/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
+++ b/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
@@ -58,9 +58,10 @@ namespace Prism.Navigation
         {
             var page = CreatePopupPageByName( name );
             ViewModelLocator.SetAutowireViewModel( page, ViewModelLocator.GetAutowireViewModel( page ) ?? true );
+            var currentPage = GetCurrentPage();
             HandleINavigatingAware( page, parameters );
             await PopupNavigation.PushAsync( page, animated );
-            HandleINavigatedAware( page, parameters, navigatedTo: true );
+            HandleINavigatedAware( currentPage, page, parameters );
         }
 
         public static Task PushPopupPageAsync( this INavigationService navigationService, string name, string key, object param, bool animated = true ) =>
@@ -71,6 +72,12 @@ namespace Prism.Navigation
             //TODO: This will need to be updated to INavigatingAware once Pre2 is released
             ( page as INavigationAware )?.OnNavigatingTo( parameters );
             ( page?.BindingContext as INavigationAware )?.OnNavigatingTo( parameters );
+        }
+
+        private static void HandleINavigatedAware( Page pageFrom, Page pageTo, NavigationParameters parameters )
+        {
+            HandleINavigatedAware( pageFrom, parameters, navigatedTo: false );
+            HandleINavigatedAware( pageTo, parameters, navigatedTo: true );
         }
 
         private static void HandleINavigatedAware( Page page, NavigationParameters parameters, bool navigatedTo )


### PR DESCRIPTION
- Implements INavigatingAware & INavigatedAware Paradigm. (Will need to be updated to use these interfaces when Prism Forms 6.3.0-pre2 is released )
- Fixes missing call to OnNavigatedFrom when pushing a new page since we never got the current page