### PR TITLE
Fixes Filter Page

### DIFF
--- a/src/Prism.Plugin.Popups.Autofac/Prism.Plugin.Popups.Autofac.nuspec
+++ b/src/Prism.Plugin.Popups.Autofac/Prism.Plugin.Popups.Autofac.nuspec
@@ -8,6 +8,8 @@
     <summary>Provides extensions to the Navigation Service to allow Prism Navigation for Popup Pages</summary>
     <description>$description$</description>
     <releaseNotes>
+v1.1.0-pre3
+-Fixes issue where the Filter Page function ends up in an infinite loop resulting in a hang during navigation. Navigation should now get the Current Page of any NavigationPage, MasterDetailPage, or TabbedPage.
 v1.1.0-pre2
 -Fixes issue where OnNavigatingTo could be called on a parent page. Will now call the Detail page of a MasterDetailPage or CurrentPage for a NavigationPage or any MultiPage&lt;&gt;. Will continue evaluating the current page until a page type is recieved that does not possess Child Pages.
 v1.1.0-pre1

--- a/src/Prism.Plugin.Popups.DryIoc/Prism.Plugin.Popups.DryIoc.nuspec
+++ b/src/Prism.Plugin.Popups.DryIoc/Prism.Plugin.Popups.DryIoc.nuspec
@@ -8,6 +8,8 @@
     <summary>Provides extensions to the Navigation Service to allow Prism Navigation for Popup Pages</summary>
     <description>$description$</description>
     <releaseNotes>
+v1.1.0-pre3
+-Fixes issue where the Filter Page function ends up in an infinite loop resulting in a hang during navigation. Navigation should now get the Current Page of any NavigationPage, MasterDetailPage, or TabbedPage.
 v1.1.0-pre2
 -Fixes issue where OnNavigatingTo could be called on a parent page. Will now call the Detail page of a MasterDetailPage or CurrentPage for a NavigationPage or any MultiPage&lt;&gt;. Will continue evaluating the current page until a page type is recieved that does not possess Child Pages.
 v1.1.0-pre1

--- a/src/Prism.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.nuspec
+++ b/src/Prism.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.nuspec
@@ -8,6 +8,8 @@
     <summary>Provides extensions to the Navigation Service to allow Prism Navigation for Popup Pages</summary>
     <description>$description$</description>
     <releaseNotes>
+v1.1.0-pre3
+-Fixes issue where the Filter Page function ends up in an infinite loop resulting in a hang during navigation. Navigation should now get the Current Page of any NavigationPage, MasterDetailPage, or TabbedPage.
 v1.1.0-pre2
 -Fixes issue where OnNavigatingTo could be called on a parent page. Will now call the Detail page of a MasterDetailPage or CurrentPage for a NavigationPage or any MultiPage&lt;&gt;. Will continue evaluating the current page until a page type is recieved that does not possess Child Pages.
 v1.1.0-pre1

--- a/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
+++ b/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
@@ -150,7 +150,10 @@ namespace Prism.Navigation
             if( page == null ) return page;
             var startPage = page;
 
-            while( page is MasterDetailPage || page is NavigationPage || page.GetType() == typeof( MultiPage<> ) )
+            var pageTypeInfo = page.GetType().GetTypeInfo();
+            while( pageTypeInfo.IsSubclassOf( typeof( MasterDetailPage ) ) || 
+                  pageTypeInfo.IsSubclassOf( typeof( NavigationPage ) ) || 
+                  pageTypeInfo.IsSubclassOf( typeof( MultiPage<> ) ) )
             {
                 if( page.GetType().GetTypeInfo().IsSubclassOf( typeof( MultiPage<> ) ) )
                 {

--- a/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
+++ b/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Prism.Mvvm;
 using Prism.Plugin.Popups;
@@ -151,15 +152,15 @@ namespace Prism.Navigation
 
             while( page is MasterDetailPage || page is NavigationPage || page.GetType() == typeof( MultiPage<> ) )
             {
-                if( page.GetType() == typeof( MultiPage<> ) )
+                if( page.GetType().GetTypeInfo().IsSubclassOf( typeof( MultiPage<> ) ) )
                 {
                     page = ( page as MultiPage<Page> ).CurrentPage;
                 }
-                else if( page.GetType() == typeof( MasterDetailPage ) )
+                else if( page.GetType().GetTypeInfo().IsSubclassOf( typeof( MasterDetailPage ) ) )
                 {
                     page = ( page as MasterDetailPage ).Detail;
                 }
-                else if( page.GetType() == typeof( NavigationPage ) )
+                else if( page.GetType().GetTypeInfo().IsSubclassOf( typeof( NavigationPage ) ) )
                 {
                     page = ( page as NavigationPage ).CurrentPage;
                 }

--- a/src/Prism.Plugin.Popups.Unity/Prism.Plugin.Popups.Unity.nuspec
+++ b/src/Prism.Plugin.Popups.Unity/Prism.Plugin.Popups.Unity.nuspec
@@ -8,6 +8,8 @@
     <summary>Provides extensions to the Navigation Service to allow Prism Navigation for Popup Pages</summary>
     <description>$description$</description>
     <releaseNotes>
+v1.1.0-pre3
+-Fixes issue where the Filter Page function ends up in an infinite loop resulting in a hang during navigation. Navigation should now get the Current Page of any NavigationPage, MasterDetailPage, or TabbedPage.
 v1.1.0-pre2
 -Fixes issue where OnNavigatingTo could be called on a parent page. Will now call the Detail page of a MasterDetailPage or CurrentPage for a NavigationPage or any MultiPage&lt;&gt;. Will continue evaluating the current page until a page type is recieved that does not possess Child Pages.
 v1.1.0-pre1


### PR DESCRIPTION
Addresses issue #16 where we would end up in an infinite loop while trying to get the current page of a MasterDetailPage, TabbedPage, or NavigationPage.