### PR TITLE
Only calls Destroy on Popup pages

### DIFF
--- a/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
+++ b/src/Prism.Plugin.Popups.Shared/PopupExtensions.cs
@@ -119,7 +119,8 @@ namespace Prism.Navigation
             {
                 pageAware?.OnNavigatedFrom( parameters );
                 contextAware?.OnNavigatedFrom( parameters );
-                HandleIDestructiblePage( page );
+                //HandleIDestructiblePage( page );
+                if (page is PopupPage) HandleIDestructiblePage( page );
             }
         }
 


### PR DESCRIPTION
This changes fixes the issue where ContentPage/MasterDetail pages that implement IDestructible call Destroy when HandleINavigatedAware is handled. The change explicitly checks for PopupPage, that way Prism can handle standard Forms page type cleanup.