### PR TITLE
Bumped Prism dependencies and addressed breaking changes

### DIFF
--- a/samples/src/PopupPluginSample.Droid/project.json
+++ b/samples/src/PopupPluginSample.Droid/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Prism.DryIoc.Forms": "7.0.0.396",
+    "Prism.DryIoc.Forms": "7.0.0.423-ci",
     "PropertyChanged.Fody": "2.2.5",
     "Rg.Plugins.Popup": "1.1.4.145-pre",
     "Xamarin.Android.Support.Design": "26.1.0.1",

--- a/samples/src/PopupPluginSample.iOS/project.json
+++ b/samples/src/PopupPluginSample.iOS/project.json
@@ -1,6 +1,6 @@
 ﻿{
   "dependencies": {
-    "Prism.DryIoc.Forms": "7.0.0.396",
+    "Prism.DryIoc.Forms": "7.0.0.423-ci",
     "PropertyChanged.Fody": "2.2.5",
     "Rg.Plugins.Popup": "1.1.4.145-pre",
     "Xamarin.FFImageLoading.Forms": "2.3.4",

--- a/samples/src/PopupPluginSample/PopupPluginSample.csproj
+++ b/samples/src/PopupPluginSample/PopupPluginSample.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="PropertyChanged.Fody" Version="2.2.5" PrivateAssets="all" />
-    <PackageReference Include="Prism.DryIoc.Forms" Version="7.0.0.396" />
+    <PackageReference Include="Prism.DryIoc.Forms" Version="7.0.0.423-ci" />
     <PackageReference Include="Rg.Plugins.Popup" Version="1.1.4.145-pre" />
     <PackageReference Include="Xamarin.Forms" Version="2.5.0.122203" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.3.0" />

--- a/samples/src/PopupPluginSample/ViewModels/BaseViewModel.cs
+++ b/samples/src/PopupPluginSample/ViewModels/BaseViewModel.cs
@@ -31,14 +31,14 @@ namespace PopupPluginSample.ViewModels
 
         public DelegateCommand GoBackCommand { get; }
 
-        public void OnNavigatedFrom(NavigationParameters parameters)
+        public void OnNavigatedFrom(INavigationParameters parameters)
         {
             parameters.Add("message", $"Hello from {GetType().Name}");
             WriteLine($"{Title} OnNavigatedFrom");
             WriteLine($"Parameters: {parameters.GetValue<string>("message")}");
         }
 
-        public void OnNavigatedTo(NavigationParameters parameters)
+        public void OnNavigatedTo(INavigationParameters parameters)
         {
             WriteLine($"{Title} OnNavigatedTo");
             Message = parameters.GetValue<string>("message");
@@ -47,7 +47,7 @@ namespace PopupPluginSample.ViewModels
             WriteLine($"NavigationService Page: {(_navigationService as IPageAware).Page.GetType().Name}");
         }
 
-        public void OnNavigatingTo(NavigationParameters parameters)
+        public void OnNavigatingTo(INavigationParameters parameters)
         {
             WriteLine($"{Title} OnNavigatingTo");
             Message = parameters.GetValue<string>("message");

--- a/samples/src/PopupPluginSample/ViewModels/PopupViewModel.cs
+++ b/samples/src/PopupPluginSample/ViewModels/PopupViewModel.cs
@@ -25,17 +25,17 @@ namespace PopupPluginSample.ViewModels
 
         public DelegateCommand NavigateBackCommand { get; }
 
-        public void OnNavigatingTo( NavigationParameters parameters )
+        public void OnNavigatingTo(INavigationParameters parameters )
         {
             System.Diagnostics.Debug.WriteLine( $"{GetType().Name} Navigating To" );
         }
 
-        public void OnNavigatedFrom( NavigationParameters parameters )
+        public void OnNavigatedFrom(INavigationParameters parameters )
         {
             System.Diagnostics.Debug.WriteLine( $"{GetType().Name} Navigated From" );
         }
 
-        public void OnNavigatedTo( NavigationParameters parameters )
+        public void OnNavigatedTo(INavigationParameters parameters )
         {
             System.Diagnostics.Debug.WriteLine( $"{GetType().Name} Navigated To" );
 

--- a/src/Prism.Plugin.Popups.Autofac/Prism.Plugin.Popups.Autofac.csproj
+++ b/src/Prism.Plugin.Popups.Autofac/Prism.Plugin.Popups.Autofac.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.Autofac.Forms" Version="7.0.0.396" />
+    <PackageReference Include="Prism.Autofac.Forms" Version="7.0.0.423-ci" />
     <ProjectReference Include="../Prism.Plugin.Popups/Prism.Plugin.Popups.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Prism.Plugin.Popups.DryIoc/Prism.Plugin.Popups.DryIoc.csproj
+++ b/src/Prism.Plugin.Popups.DryIoc/Prism.Plugin.Popups.DryIoc.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.DryIoc.Forms" Version="7.0.0.396" />
+    <PackageReference Include="Prism.DryIoc.Forms" Version="7.0.0.423-ci" />
     <ProjectReference Include="../Prism.Plugin.Popups/Prism.Plugin.Popups.csproj" />
   </ItemGroup>
 

--- a/src/Prism.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.csproj
+++ b/src/Prism.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.Ninject.Forms" Version="7.0.0.336-pre" />
+    <PackageReference Include="Prism.Ninject.Forms" Version="7.0.0.354-ci" />
     <ProjectReference Include="../Prism.Plugin.Popups/Prism.Plugin.Popups.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Prism.Plugin.Popups.Unity/Prism.Plugin.Popups.Unity.csproj
+++ b/src/Prism.Plugin.Popups.Unity/Prism.Plugin.Popups.Unity.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Prism.Unity.Forms" Version="7.0.0.396" />
+    <PackageReference Include="Prism.Unity.Forms" Version="7.0.0.423-ci" />
     <ProjectReference Include="../Prism.Plugin.Popups/Prism.Plugin.Popups.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Prism.Plugin.Popups/BackgroundPopupDismissalBehavior.cs
+++ b/src/Prism.Plugin.Popups/BackgroundPopupDismissalBehavior.cs
@@ -44,7 +44,7 @@ namespace Prism.Plugin.Popups
             InvokePageInterfaces(TopPage(), parameters, true);
         }
 
-        private void InvokePageInterfaces(Page page, NavigationParameters parameters, bool navigatedTo)
+        private void InvokePageInterfaces(Page page, INavigationParameters parameters, bool navigatedTo)
         {
             PageUtilities.InvokeViewAndViewModelAction<INavigatedAware>(page, (view) => {
                 if(navigatedTo)

--- a/src/Prism.Plugin.Popups/PopupExtensions.cs
+++ b/src/Prism.Plugin.Popups/PopupExtensions.cs
@@ -30,7 +30,7 @@ namespace Prism.Navigation
         public static Task ClearPopupStackAsync(this INavigationService navigationService, string key, object param, bool animated = true) =>
             navigationService.ClearPopupStackAsync(GetNavigationParameters(key, param, NavigationMode.Back), animated);
 
-        public static async Task ClearPopupStackAsync(this INavigationService navigationService, NavigationParameters parameters = null, bool animated = true)
+        public static async Task ClearPopupStackAsync(this INavigationService navigationService, INavigationParameters parameters = null, bool animated = true)
         {
             while (s_popupStack.Count > 0)
             {
@@ -105,7 +105,7 @@ namespace Prism.Navigation
             HandleINavigatedAware(pageTo, parameters, navigatedTo: true);
         }
 
-        private static void HandleINavigatedAware(Page page, NavigationParameters parameters, bool navigatedTo)
+        private static void HandleINavigatedAware(Page page, INavigationParameters parameters, bool navigatedTo)
         {
             if (page == null) return;
             if (parameters == null)
@@ -152,11 +152,13 @@ namespace Prism.Navigation
         //    parameters.Add( KnownNavigationParameters.NavigationMode, mode );
         //}
 
-        private static NavigationParameters GetNavigationParameters(string key, object param, NavigationMode mode) =>
-            new NavigationParameters()
+        private static INavigationParameters GetNavigationParameters(string key, object param, NavigationMode mode)
+        {
+            return (INavigationParameters)new NavigationParameters()
             {
                 { key, param }
             }.AddNavigationMode(mode);
+        }
 
         //private static void VerifyPageIsRegistered( string name )
         //{

--- a/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
+++ b/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
@@ -14,7 +14,10 @@ namespace Prism.Plugin.Popups
 {
     public class PopupPageNavigationService : PageNavigationService
     {
-        protected IPopupNavigation _popupNavigation { get; }
+        protected IPopupNavigation _popupNavigation
+        {
+            get;
+        }
 
         public PopupPageNavigationService(IPopupNavigation popupNavigation, IContainerExtension container,
                                           IApplicationProvider applicationProvider, IPageBehaviorFactory pageBehaviorFactor,
@@ -24,7 +27,7 @@ namespace Prism.Plugin.Popups
             _popupNavigation = popupNavigation;
         }
 
-        public override async Task<bool> GoBackAsync(NavigationParameters parameters)
+        public override async Task<INavigationResult> GoBackAsync(INavigationParameters parameters)
         {
             try
             {
@@ -47,7 +50,7 @@ namespace Prism.Plugin.Popups
                             PageUtilities.OnNavigatedTo(previousPage, segmentParameters);
                             PageUtilities.InvokeViewAndViewModelAction<IActiveAware>(previousPage, a => a.IsActive = true);
                             PageUtilities.DestroyPage(popupPage);
-                            return true;
+                            return new NavigationResult() { Success = true };
                         }
                         break;
                     default:
@@ -57,14 +60,14 @@ namespace Prism.Plugin.Popups
             catch (Exception e)
             {
                 _logger.Log(e.ToString(), Category.Exception, Priority.High);
-                return false;
+                return new NavigationResult() { Success = false, Exception = e };
             }
             finally
             {
                 NavigationSource = PageNavigationSource.Device;
             }
 
-            return false;
+            return new NavigationResult() { Success = false };
         }
 
         protected override async Task<Page> DoPop(INavigation navigation, bool useModalNavigation, bool animated)

--- a/src/Prism.Plugin.Popups/PopupUtilities.cs
+++ b/src/Prism.Plugin.Popups/PopupUtilities.cs
@@ -12,15 +12,18 @@ namespace Prism.Plugin.Popups
     {
         public const string NavigationModeKey = "__NavigationMode";
 
-        public static NavigationParameters CreateNewNavigationParameters() =>
-            new NavigationParameters().AddNavigationMode(NavigationMode.New);
+        public static INavigationParameters CreateNewNavigationParameters() =>
+             ((INavigationParameters)new NavigationParameters()).AddNavigationMode(NavigationMode.New);
 
-        public static NavigationParameters CreateBackNavigationParameters() =>
-            new NavigationParameters().AddNavigationMode(NavigationMode.Back);
-
-        public static NavigationParameters AddNavigationMode(this NavigationParameters parameters, NavigationMode mode)
+        public static INavigationParameters CreateBackNavigationParameters()
         {
-            parameters.AddInternalParameter(NavigationModeKey, mode);
+            return ((INavigationParameters)new NavigationParameters()).AddNavigationMode(NavigationMode.Back);
+        }
+
+        public static INavigationParameters AddNavigationMode(this INavigationParameters parameters, NavigationMode mode)
+        {
+            NavigationParameters y;
+            parameters.Add(NavigationModeKey, mode);
             return parameters;
         }
 

--- a/src/Prism.Plugin.Popups/Prism.Plugin.Popups.csproj
+++ b/src/Prism.Plugin.Popups/Prism.Plugin.Popups.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Rg.Plugins.Popup" Version="1.1.4.145-pre" />
-    <PackageReference Include="Prism.Forms" Version="7.0.0.396" />
+    <PackageReference Include="Prism.Forms" Version="7.0.0.423-ci" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This PR brings `Prism.Plugin.Popups` up to date with the latest prism CI packages and addresses the breaking changes that have occurred around Navigation.

closes #55