### PR TITLE
Fixes AppVeyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,10 @@ build:
   project: '%path_to_sln%'
   verbosity: minimal
 after_build:
-- cmd: msbuild Prism.Plugin.Popups/Prism.Plugin.Popups.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
-- cmd: msbuild Prism.Plugin.Popups.Autofac/Prism.Plugin.Popups.Autofac.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
-- cmd: msbuild Prism.Plugin.Popups.DryIoc/Prism.Plugin.Popups.DryIoc.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
-- cmd: msbuild Prism.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
-- cmd: msbuild Prism.Plugin.Popups.Unity/Prism.Plugin.Popups.Unity.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild src/Prism.Plugin.Popups/Prism.Plugin.Popups.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild src/Prism.Plugin.Popups.Autofac/Prism.Plugin.Popups.Autofac.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild src/Prism.Plugin.Popups.DryIoc/Prism.Plugin.Popups.DryIoc.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild src/.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild src/Prism.Plugin.Popups.Unity/Prism.Plugin.Popups.Unity.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
 artifacts:
 - path: '**/Prism.Plugin.Popups.*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ after_build:
 - cmd: msbuild src/Prism.Plugin.Popups/Prism.Plugin.Popups.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
 - cmd: msbuild src/Prism.Plugin.Popups.Autofac/Prism.Plugin.Popups.Autofac.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
 - cmd: msbuild src/Prism.Plugin.Popups.DryIoc/Prism.Plugin.Popups.DryIoc.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
-- cmd: msbuild src/.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild src/Prism.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
 - cmd: msbuild src/Prism.Plugin.Popups.Unity/Prism.Plugin.Popups.Unity.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
 artifacts:
 - path: '**/Prism.Plugin.Popups.*.nupkg'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+environment:
+  path_to_sln: Prism.Plugin.Popups.sln 
+skip_tags: true
+image: Visual Studio 2017
+install:
+  - choco install gitversion.portable -pre -y
+  - cinst gitlink -version 2.4.1 -y
+before_build:
+- cmd: gitversion /l console /output buildserver
+- cmd: msbuild %path_to_sln% /t:restore /p:PackageVersion=%GitVersion_FullSemVer%
+build:
+  project: '%path_to_sln%'
+  verbosity: minimal
+after_build:
+- cmd: msbuild Prism.Plugin.Popups/Prism.Plugin.Popups.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild Prism.Plugin.Popups.Autofac/Prism.Plugin.Popups.Autofac.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild Prism.Plugin.Popups.DryIoc/Prism.Plugin.Popups.DryIoc.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild Prism.Plugin.Popups.Ninject/Prism.Plugin.Popups.Ninject.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+- cmd: msbuild Prism.Plugin.Popups.Unity/Prism.Plugin.Popups.Unity.csproj /t:Pack /p:PackageVersion=%GitVersion_FullSemVer%
+artifacts:
+- path: '**/Prism.Plugin.Popups.*.nupkg'


### PR DESCRIPTION
As per #57

This adds an AppVeyor.yml to get the build working.
I have used GitVersion for version stamping - not sure if you have some other mechanism in mind.

This is the resultant / working build here: https://ci.appveyor.com/project/dazinator/prism-plugin-popups