### PR TITLE
Fixed popup nav service issue with pages which have partial views

### DIFF
--- a/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
+++ b/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
@@ -132,7 +132,7 @@ namespace Prism.Plugin.Popups
 #if !NETSTANDARD1_0
             if(view is Page page)
             {
-                BindableProperty partialViewsProperty = typeof(ViewModelLocator).GetProperty("PartialViewsProperty", BindingFlags.Static & BindingFlags.NonPublic).GetValue(null) as BindableProperty;
+                BindableProperty partialViewsProperty = typeof(ViewModelLocator).GetField("PartialViewsProperty", BindingFlags.Static | BindingFlags.NonPublic).GetValue(null) as BindableProperty;
                 var partials = (List<BindableObject>)page.GetValue(partialViewsProperty);
                 foreach (var partial in partials ?? new List<BindableObject>())
                 {


### PR DESCRIPTION
ViewModelLocator has a non-public static **field** named PartialViewsProperty.