### PR TITLE
Bugfix/navigation to other page fix

### DIFF
--- a/samples/src/PopupPluginSample/ViewModels/PopupViewModel.cs
+++ b/samples/src/PopupPluginSample/ViewModels/PopupViewModel.cs
@@ -14,7 +14,6 @@ namespace PopupPluginSample.ViewModels
             System.Diagnostics.Debug.WriteLine( "Hello from the PopupViewViewModel" );
             _navigationService = navigationService;
             NavigateBackCommand = new DelegateCommand( OnNavigateBackCommandExecuted );
-            NavigateToCommand = new DelegateCommand<string>(OnNavigateToCommandExecuted);
         }
 
         private string _message;
@@ -25,8 +24,6 @@ namespace PopupPluginSample.ViewModels
         }
 
         public DelegateCommand NavigateBackCommand { get; }
-
-        public DelegateCommand<string> NavigateToCommand { get; }
 
         public void OnNavigatingTo(INavigationParameters parameters)
         {
@@ -53,12 +50,6 @@ namespace PopupPluginSample.ViewModels
             await _navigationService.GoBackAsync(new NavigationParameters{
                 { "message", "Hello from the Popup View" }
             });
-        }
-
-        private async void OnNavigateToCommandExecuted(string navPath)
-        {
-            await _navigationService.GoBackToRootAsync();
-            await _navigationService.NavigateAsync(navPath);
         }
     }
 }

--- a/samples/src/PopupPluginSample/ViewModels/PopupViewModel.cs
+++ b/samples/src/PopupPluginSample/ViewModels/PopupViewModel.cs
@@ -14,6 +14,7 @@ namespace PopupPluginSample.ViewModels
             System.Diagnostics.Debug.WriteLine( "Hello from the PopupViewViewModel" );
             _navigationService = navigationService;
             NavigateBackCommand = new DelegateCommand( OnNavigateBackCommandExecuted );
+            NavigateToCommand = new DelegateCommand<string>(OnNavigateToCommandExecuted);
         }
 
         private string _message;
@@ -24,6 +25,8 @@ namespace PopupPluginSample.ViewModels
         }
 
         public DelegateCommand NavigateBackCommand { get; }
+
+        public DelegateCommand<string> NavigateToCommand { get; }
 
         public void OnNavigatingTo(INavigationParameters parameters)
         {
@@ -50,6 +53,12 @@ namespace PopupPluginSample.ViewModels
             await _navigationService.GoBackAsync(new NavigationParameters{
                 { "message", "Hello from the Popup View" }
             });
+        }
+
+        private async void OnNavigateToCommandExecuted(string navPath)
+        {
+            await _navigationService.GoBackToRootAsync();
+            await _navigationService.NavigateAsync(navPath);
         }
     }
 }

--- a/samples/src/PopupPluginSample/Views/PopupView.xaml
+++ b/samples/src/PopupPluginSample/Views/PopupView.xaml
@@ -2,7 +2,7 @@
 <popup:PopupPage xmlns="http://xamarin.com/schemas/2014/forms" 
                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                  xmlns:popup="clr-namespace:Rg.Plugins.Popup.Pages;assembly=Rg.Plugins.Popup"
-                 xmlns:prism="clr-namespace:Prism.Mvvm;assembly=Prism.Forms" 
+                 xmlns:prism="http://prismlibrary.com" 
                  prism:ViewModelLocator.AutowireViewModel="True"
                  Padding="100"
                  x:Class="PopupPluginSample.Views.PopupView">
@@ -14,7 +14,6 @@
         <Label Text="{Binding Message}" />
         <Button Text="Navigate Back" Command="{Binding NavigateBackCommand}" />
     <Button Text="Navigate to Menu Page"
-            Command="{Binding NavigateToCommand}"
-            CommandParameter="MenuPage" />
+            Command="{prism:NavigateTo '/MenuPage'}" />
   </StackLayout>
 </popup:PopupPage>

--- a/samples/src/PopupPluginSample/Views/PopupView.xaml
+++ b/samples/src/PopupPluginSample/Views/PopupView.xaml
@@ -13,5 +13,8 @@
                 BackgroundColor="White">
         <Label Text="{Binding Message}" />
         <Button Text="Navigate Back" Command="{Binding NavigateBackCommand}" />
-    </StackLayout>
+    <Button Text="Navigate to Menu Page"
+            Command="{Binding NavigateToCommand}"
+            CommandParameter="MenuPage" />
+  </StackLayout>
 </popup:PopupPage>

--- a/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
+++ b/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
@@ -302,7 +302,7 @@ namespace Prism.Plugin.Popups
                     if (_popupNavigation.PopupStack.Any())
                     {
                         await _popupNavigation.PopAllAsync(animated);
-                        currentPage = _applicationProvider.MainPage;
+                        currentPage = PageUtilities.GetCurrentPage(_applicationProvider.MainPage);
                     }
                         
                     await base.DoPush(currentPage, page, useModalNavigation, animated, insertBeforeLast, navigationOffset);

--- a/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
+++ b/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
@@ -300,7 +300,11 @@ namespace Prism.Plugin.Popups
                     break;
                 default:
                     if (_popupNavigation.PopupStack.Any())
+                    {
                         await _popupNavigation.PopAllAsync(animated);
+                        currentPage = _applicationProvider.MainPage;
+                    }
+                        
                     await base.DoPush(currentPage, page, useModalNavigation, animated, insertBeforeLast, navigationOffset);
                     break;
             }


### PR DESCRIPTION
# Description
Fixes #106 
Fix is to reset the `currentPage` variable to the current MainPage after popping the PopupNavigationStack. Not tested very extensively, but seems to get the job done. 
Tested on iOS and Android, added a sample for testing this navigation.