### PR TITLE
Added attached properties for controlling PopupPage padding

### DIFF
--- a/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
@@ -7,6 +7,7 @@ using Prism.AppModel;
 using Prism.Common;
 using Prism.Ioc;
 using Prism.Mvvm;
+using Prism.Plugin.Popups;
 using Prism.Services.Dialogs.Xaml;
 using Rg.Plugins.Popup.Contracts;
 using Rg.Plugins.Popup.Pages;
@@ -35,7 +36,8 @@ namespace Prism.Services.Dialogs.Popups
                 parameters = UriParsingHelper.GetSegmentParameters(name, parameters);
 
                 var view = CreateViewFor(UriParsingHelper.GetSegmentName(name));
-                var popupPage = new PopupPage();
+                var popupPage = CreatePopupPageForView(view);
+
                 var dialogAware = InitializeDialog(view, parameters);
 
                 if (!parameters.TryGetValue<bool>(KnownDialogParameters.CloseOnBackgroundTapped, out var closeOnBackgroundTapped))
@@ -106,7 +108,18 @@ namespace Prism.Services.Dialogs.Popups
             }
         }
 
-        private PopupPage CreatePopup() => new PopupPage();
+        private static PopupPage CreatePopupPageForView(BindableObject view)
+        { 
+            var popupPage =  new PopupPage();
+
+            var hasSystemPadding = view.GetValue(Plugin.Popups.Popups.HasSystemPaddingProperty);
+            if (hasSystemPadding != null) popupPage.HasSystemPadding = (bool)hasSystemPadding;
+
+            var hasKeyboardOffset = view.GetValue(Plugin.Popups.Popups.HasKeyboardOffsetProperty);
+            if (hasKeyboardOffset != null) popupPage.HasKeyboardOffset = (bool)hasKeyboardOffset;
+
+            return popupPage;
+        }
 
         private View CreateViewFor(string name)
         {

--- a/src/Prism.Plugin.Popups/Popups.cs
+++ b/src/Prism.Plugin.Popups/Popups.cs
@@ -1,0 +1,31 @@
+﻿using Xamarin.Forms;
+
+namespace Prism.Plugin.Popups
+{
+    public static class Popups
+    {
+        public static readonly BindableProperty HasSystemPaddingProperty = BindableProperty.CreateAttached("HasSystemPadding", typeof(bool), typeof(View), false);
+        
+        public static bool GetHasSystemPadding(BindableObject view)
+        {
+            return (bool)view.GetValue(HasSystemPaddingProperty);
+        }
+        
+        public static void SetHasSystemPadding(BindableObject view, bool value)
+        {
+            view.SetValue(HasSystemPaddingProperty, value);
+        }
+
+        public static readonly BindableProperty HasKeyboardOffsetProperty = BindableProperty.CreateAttached("HasKeyboardOffset", typeof(bool), typeof(View), false);
+
+        public static bool GetHasKeyboardOffset(BindableObject view)
+        {
+            return (bool)view.GetValue(HasKeyboardOffsetProperty);
+        }
+
+        public static void SetHasKeyboardOffset(BindableObject view, bool value)
+        {
+            view.SetValue(HasKeyboardOffsetProperty, value);
+        }
+    }
+}


### PR DESCRIPTION
There are scenarios (e.g. https://github.com/rotorgames/Rg.Plugins.Popup/issues/225) when the [PopupPage properties](https://github.com/rotorgames/Rg.Plugins.Popup/wiki/PopupPage#properties) need to be set. This PR creates attached properties that will set the PopupPage properties after the page is created in the Prism.Plugins.Popup internals.

**Usage:**

Reference `Prism.Plugin.Popups` and add the attached properties to the view that will be hosted in the popup/dialog.

```
xmlns:popups="clr-namespace:Prism.Plugin.Popups;assembly=Prism.Plugin.Popups"
popups:Popups.HasKeyboardOffset="False"
popups:Popups.HasSystemPadding="True"
```