### PR TITLE
Call IDestructible when clearing PopupStack

### DIFF
--- a/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
+++ b/src/Prism.Plugin.Popups/PopupPageNavigationService.cs
@@ -306,6 +306,9 @@ namespace Prism.Plugin.Popups
                 default:
                     if (_popupNavigation.PopupStack.Any())
                     {
+                        foreach (var pageToPop in _popupNavigation.PopupStack)
+                            PageUtilities.DestroyPage(pageToPop);
+
                         await _popupNavigation.PopAllAsync(animated);
                     }
 

--- a/tests/Prism.Plugin.Popups.Tests.Shared/Mocks/ViewModels/PopupPageMockViewModel.cs
+++ b/tests/Prism.Plugin.Popups.Tests.Shared/Mocks/ViewModels/PopupPageMockViewModel.cs
@@ -8,11 +8,13 @@ using System.Text;
 
 namespace Prism.Plugin.Popups.Tests.Mocks.ViewModels
 {
-    public class PopupPageMockViewModel : BindableBase, INavigatedAware
+    public class PopupPageMockViewModel : BindableBase, INavigatedAware, IDestructible
     {
         private IEventAggregator _eventAggregator { get; }
 
         public INavigationService NavigationService { get; }
+
+        public int Destroyed { get; private set; }
 
         public PopupPageMockViewModel(INavigationService navigationService, IEventAggregator eventAggregator)
         {
@@ -30,6 +32,11 @@ namespace Prism.Plugin.Popups.Tests.Mocks.ViewModels
         public void OnNavigatedTo(INavigationParameters parameters)
         {
             NavigatedTo = true;
+        }
+
+        public void Destroy()
+        {
+            Destroyed++;
         }
     }
 }

--- a/tests/Prism.Plugin.Popups.Tests.Shared/Tests/NavigationServiceFixture.cs
+++ b/tests/Prism.Plugin.Popups.Tests.Shared/Tests/NavigationServiceFixture.cs
@@ -125,5 +125,41 @@ namespace Prism.Plugin.Popups.Tests
             Assert.True(clearResult.Success);
             Assert.Empty(PopupNavigation.Instance.PopupStack);
         }
+
+        [Fact]
+        public async Task PopupPageIsDestroyed_WhenNavigatingBack()
+        {
+            var app = GetApp();
+            app.MainPage = new ContentPage();
+            await app.GetNavigationService().NavigateAsync("PopupPageMock");
+
+            var popupPage = PopupNavigation.Instance.PopupStack.First();
+            Assert.IsType<PopupPageMockViewModel>(popupPage.BindingContext);
+            var vm = (PopupPageMockViewModel)popupPage.BindingContext;
+
+            Assert.Equal(0, vm.Destroyed);
+
+            await app.GetNavigationService(popupPage).GoBackAsync();
+
+            Assert.Equal(1, vm.Destroyed);
+        }
+
+        [Fact]
+        public async Task PopupPageIsDestroyed_WhenNavigatingToContentPage()
+        {
+            var app = GetApp();
+            app.MainPage = new ContentPage();
+            await app.GetNavigationService().NavigateAsync("PopupPageMock");
+
+            var popupPage = PopupNavigation.Instance.PopupStack.First();
+            Assert.IsType<PopupPageMockViewModel>(popupPage.BindingContext);
+            var vm = (PopupPageMockViewModel)popupPage.BindingContext;
+
+            Assert.Equal(0, vm.Destroyed);
+
+            await app.GetNavigationService(popupPage).NavigateAsync("ViewA");
+
+            Assert.Equal(1, vm.Destroyed);
+        }
     }
 }


### PR DESCRIPTION
# Description

The PopupStack should be popped when Navigating to a non-PopupPage. Before the stack is cleared however we need to ensure that IDestructible is called so that resources can be released and not create memory leaks.

## Fixes Issues

- fixes #156