### PR TITLE
Provide a way to disable popup animation on Dialogs

### DIFF
--- a/samples/src/PopupPluginSample/App.xaml.cs
+++ b/samples/src/PopupPluginSample/App.xaml.cs
@@ -48,6 +48,7 @@ namespace PopupPluginSample
             containerRegistry.RegisterForNavigation<NavigationPage>();
 
             containerRegistry.RegisterDialog<SampleDialog, SampleDialogViewModel>();
+            containerRegistry.RegisterDialog<NotAnimatedDialog, SampleDialogViewModel>();
         }
 
         private void SetupLoggingListeners()

--- a/samples/src/PopupPluginSample/Dialogs/NotAnimatedDialog.xaml
+++ b/samples/src/PopupPluginSample/Dialogs/NotAnimatedDialog.xaml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<StackLayout xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:xaml="clr-namespace:Prism.Plugin.Popups.Dialogs.Xaml;assembly=Prism.Plugin.Popups"
+             mc:Ignorable="d"
+             x:Class="PopupPluginSample.Dialogs.NotAnimatedDialog"
+             BackgroundColor="White"
+             Padding="20"
+             xaml:PopupDialogLayout.IsAnimationEnabled="False">
+  <Label Text="Hello Prism Dialogs!" />
+  <Button Text="Close" Command="{Binding CloseCommand}" />
+</StackLayout>

--- a/samples/src/PopupPluginSample/Dialogs/NotAnimatedDialog.xaml.cs
+++ b/samples/src/PopupPluginSample/Dialogs/NotAnimatedDialog.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace PopupPluginSample.Dialogs
+{
+    public partial class NotAnimatedDialog
+    {
+        public NotAnimatedDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/samples/src/PopupPluginSample/PopupPluginSample.csproj
+++ b/samples/src/PopupPluginSample/PopupPluginSample.csproj
@@ -16,10 +16,4 @@
     <ProjectReference Include="..\..\..\src\Prism.Plugin.Popups\Prism.Plugin.Popups.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="Dialogs\NotAnimatedDialog.xaml.cs">
-      <DependentUpon>NotAnimatedDialog.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
 </Project>

--- a/samples/src/PopupPluginSample/PopupPluginSample.csproj
+++ b/samples/src/PopupPluginSample/PopupPluginSample.csproj
@@ -16,4 +16,10 @@
     <ProjectReference Include="..\..\..\src\Prism.Plugin.Popups\Prism.Plugin.Popups.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Dialogs\NotAnimatedDialog.xaml.cs">
+      <DependentUpon>NotAnimatedDialog.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/samples/src/PopupPluginSample/Views/MenuPage.xaml
+++ b/samples/src/PopupPluginSample/Views/MenuPage.xaml
@@ -18,11 +18,7 @@
       <Button Text="Tabbed Page" Command="{prism:NavigateTo '/TabbedRoot'}" />
       <Button Text="Navigation Page" Command="{prism:NavigateTo '/NavigationRoot/MainPage'}" />
       <Button Text="Sample Dialog" Command="{prism:ShowDialog SampleDialog}" />
-      <Button Text="Sample Dialog (not animated)" Command="{prism:ShowDialog SampleDialog}">
-        <Button.CommandParameter>
-          <prism:Parameter Key="{x:Static dialogs:KnownPopupDialogParameters.IsAnimationEnabled}" Value="False" />
-        </Button.CommandParameter>
-      </Button>
+      <Button Text="Dialog (not animated)" Command="{prism:ShowDialog NotAnimatedDialog}" />
       <Button Text="ViewA" Command="{prism:NavigateTo ViewA}" />
       <!--        <Button Text="Content Page" Command="NavigateCommand" CommandParameter="MainPage" />-->
     </StackLayout>

--- a/samples/src/PopupPluginSample/Views/MenuPage.xaml
+++ b/samples/src/PopupPluginSample/Views/MenuPage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:prism="http://prismlibrary.com"
              xmlns:essentials="clr-namespace:Xamarin.Essentials;assembly=Xamarin.Essentials"
+             xmlns:dialogs="clr-namespace:Prism.Plugin.Popups.Dialogs;assembly=Prism.Plugin.Popups"
              x:Class="PopupPluginSample.Views.MenuPage">
 
   <Grid>
@@ -17,6 +18,11 @@
       <Button Text="Tabbed Page" Command="{prism:NavigateTo '/TabbedRoot'}" />
       <Button Text="Navigation Page" Command="{prism:NavigateTo '/NavigationRoot/MainPage'}" />
       <Button Text="Sample Dialog" Command="{prism:ShowDialog SampleDialog}" />
+      <Button Text="Sample Dialog (not animated)" Command="{prism:ShowDialog SampleDialog}">
+        <Button.CommandParameter>
+          <prism:Parameter Key="{x:Static dialogs:KnownPopupDialogParameters.IsAnimationEnabled}" Value="False" />
+        </Button.CommandParameter>
+      </Button>
       <Button Text="ViewA" Command="{prism:NavigateTo ViewA}" />
       <!--        <Button Text="Content Page" Command="NavigateCommand" CommandParameter="MainPage" />-->
     </StackLayout>

--- a/src/Prism.Plugin.Popups/Dialogs/KnownPopupDialogParameters.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/KnownPopupDialogParameters.cs
@@ -1,0 +1,7 @@
+﻿namespace Prism.Plugin.Popups.Dialogs
+{
+    public static class KnownPopupDialogParameters
+    {
+        public const string Animated = "animated";
+    }
+}

--- a/src/Prism.Plugin.Popups/Dialogs/KnownPopupDialogParameters.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/KnownPopupDialogParameters.cs
@@ -2,6 +2,14 @@
 {
     public static class KnownPopupDialogParameters
     {
+        /// <summary>
+        /// Controls whether the popup dialog action (show/close) shall be animated
+        /// </summary>
         public const string Animated = "animated";
+
+        /// <summary>
+        /// Controls whether the popup page has show and close animations enabled
+        /// </summary>
+        public const string IsAnimationEnabled = "isAnimationEnabled";
     }
 }

--- a/src/Prism.Plugin.Popups/Dialogs/KnownPopupDialogParameters.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/KnownPopupDialogParameters.cs
@@ -6,10 +6,5 @@
         /// Controls whether the popup dialog action (show/close) shall be animated
         /// </summary>
         public const string Animated = "animated";
-
-        /// <summary>
-        /// Controls whether the popup page has show and close animations enabled
-        /// </summary>
-        public const string IsAnimationEnabled = "isAnimationEnabled";
     }
 }

--- a/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
@@ -8,6 +8,7 @@ using Prism.Common;
 using Prism.Ioc;
 using Prism.Mvvm;
 using Prism.Plugin.Popups;
+using Prism.Plugin.Popups.Dialogs;
 using Prism.Services.Dialogs.Xaml;
 using Rg.Plugins.Popup.Contracts;
 using Rg.Plugins.Popup.Pages;
@@ -48,6 +49,9 @@ namespace Prism.Services.Dialogs.Popups
                         closeOnBackgroundTapped = dialogLayoutCloseOnBackgroundTapped.Value;
                     }
                 }
+
+                if (!parameters.TryGetValue<bool>(KnownPopupDialogParameters.Animated, out var animated))
+                    animated = true;
 
                 dialogAware.RequestClose += DialogAware_RequestClose;
 
@@ -100,7 +104,7 @@ namespace Prism.Services.Dialogs.Popups
                     popupPage.BackgroundClicked += CloseOnBackgroundClicked;
                 }
 
-                PushPopupPage(popupPage, view);
+                PushPopupPage(popupPage, view, animated);
             }
             catch (Exception ex)
             {
@@ -204,7 +208,7 @@ namespace Prism.Services.Dialogs.Popups
             }
         }
 
-        private async void PushPopupPage(PopupPage popupPage, View dialogView)
+        private async void PushPopupPage(PopupPage popupPage, View dialogView, bool animated = true)
         {
             View mask = DialogLayout.GetMask(dialogView);
 
@@ -255,7 +259,7 @@ namespace Prism.Services.Dialogs.Popups
 
             overlay.Children.Add(dialogView);
             popupPage.Content = overlay;
-            await _popupNavigation.PushAsync(popupPage);
+            await _popupNavigation.PushAsync(popupPage, animated);
         }
 
         private static Style GetOverlayStyle(View popupView)

--- a/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
@@ -9,6 +9,7 @@ using Prism.Ioc;
 using Prism.Mvvm;
 using Prism.Plugin.Popups;
 using Prism.Plugin.Popups.Dialogs;
+using Prism.Plugin.Popups.Dialogs.Xaml;
 using Prism.Services.Dialogs.Xaml;
 using Rg.Plugins.Popup.Contracts;
 using Rg.Plugins.Popup.Pages;
@@ -52,6 +53,13 @@ namespace Prism.Services.Dialogs.Popups
 
                 if (!parameters.TryGetValue<bool>(KnownPopupDialogParameters.Animated, out var animated))
                     animated = true;
+
+                if (!parameters.TryGetValue<bool>(KnownPopupDialogParameters.IsAnimationEnabled, out var isAnimationEnabled))
+                {
+                    var popupDialogLayoutIsAnimationEnabled = PopupDialogLayout.GetIsAnimationEnabled(view);
+                    isAnimationEnabled = popupDialogLayoutIsAnimationEnabled ?? true;
+                }
+                popupPage.IsAnimationEnabled = isAnimationEnabled;
 
                 dialogAware.RequestClose += DialogAware_RequestClose;
 

--- a/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
@@ -54,12 +54,8 @@ namespace Prism.Services.Dialogs.Popups
                 if (!parameters.TryGetValue<bool>(KnownPopupDialogParameters.Animated, out var animated))
                     animated = true;
 
-                if (!parameters.TryGetValue<bool>(KnownPopupDialogParameters.IsAnimationEnabled, out var isAnimationEnabled))
-                {
-                    var popupDialogLayoutIsAnimationEnabled = PopupDialogLayout.GetIsAnimationEnabled(view);
-                    isAnimationEnabled = popupDialogLayoutIsAnimationEnabled ?? true;
-                }
-                popupPage.IsAnimationEnabled = isAnimationEnabled;
+                var popupDialogLayoutIsAnimationEnabled = PopupDialogLayout.GetIsAnimationEnabled(view);
+                popupPage.IsAnimationEnabled = popupDialogLayoutIsAnimationEnabled ?? true;
 
                 dialogAware.RequestClose += DialogAware_RequestClose;
 

--- a/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
@@ -179,6 +179,9 @@ namespace Prism.Services.Dialogs.Popups
                     parameters = new DialogParameters();
                 }
 
+                if (!parameters.TryGetValue<bool>(KnownPopupDialogParameters.Animated, out var animated))
+                    animated = true;
+
                 var dialogAware = GetDialogController(dialogView);
 
                 if (!dialogAware.CanCloseDialog())
@@ -187,7 +190,7 @@ namespace Prism.Services.Dialogs.Popups
                 }
 
                 dialogAware.OnDialogClosed();
-                _popupNavigation.RemovePageAsync(popupPage);
+                _popupNavigation.RemovePageAsync(popupPage, animated);
 
                 return new DialogResult
                 {

--- a/src/Prism.Plugin.Popups/Dialogs/Xaml/PopupDialogLayout.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/Xaml/PopupDialogLayout.cs
@@ -1,0 +1,16 @@
+﻿using Xamarin.Forms;
+
+namespace Prism.Plugin.Popups.Dialogs.Xaml
+{
+    public static class PopupDialogLayout
+    {
+        public static readonly BindableProperty IsAnimationEnabledProperty =
+            BindableProperty.CreateAttached("IsAnimationEnabled", typeof(bool?), typeof(PopupDialogLayout), null);
+
+        public static bool? GetIsAnimationEnabled(BindableObject bindable) =>
+            (bool?)bindable.GetValue(IsAnimationEnabledProperty);
+
+        public static void SetIsAnimationEnabled(BindableObject bindable, bool? value) =>
+            bindable.SetValue(IsAnimationEnabledProperty, value);
+    }
+}


### PR DESCRIPTION
### Description
There is currently no way of disabling the animations of popup dialogs. This enhancement shall provide the user of the library with more control over how popup dialogs are presented.

#### Possible Solutions
With Rg.Plugins.Popups there are 2 ways to control animations of popups:
1. Set the `animate` parameter when calling `IPopupNavigation.PushAsync(PopupPage page, bool animate = true)` and `IPopupNavigation.RemovePageAsync(PopupPage page, bool animate = true)`.
This only controls animations for a single action, push or remove.
2. Set the `IsAnimationEnabled` property on the `PopupPage` that is passed into the methods of `IPopupNavigation`.
This disables push and remove animations altogether.

#### Implementation
1. Add `KnownPopupDialogParameters.Animated`. Controls the `animate` parameter of the popup dialog action whose dialog parameters contain this parameter.
2. Add `KnownPopupDialogParameters.IsAnimationEnabled`. Sets the `IsAnimationEnabled` property of the `PopupPage` after creating it. Also add BindableProperty `PopupDialogLayout.IsAnimationEnabledProperty` analogous to BindableProperties in `DialogLayout` to provide a way of controlling the animation directly in the XAML of the dialog.

I also added another button to the sample, which opens the `SampleDialog` with `IsAnimationEnabled=false` to showcase the new feature.

#### Fixes Issues

- fixes #165 