### PR TITLE
remove strong naming

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,13 +32,6 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- Strong Naming -->
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)plugin.snk</AssemblyOriginatorKeyFile>
-    <DelaySign>false</DelaySign>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <!-- Nuget source link -->
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
# Description

Fix for Strong Assembly naming issue for Wpf apps

- fixes #197
- fixes #196