### PR TITLE
Fix dismissal on background tapped

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
     <PackageTags>prism popups xamarin.forms</PackageTags>
     <PackageReleaseNotes>See the GitHub Release Notes</PackageReleaseNotes>
     <XunitRunnerConfigurationJson>$(MSBuildThisFileDirectory)xunit.runner.json</XunitRunnerConfigurationJson>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <!-- CI Helpers -->

--- a/samples/src/PopupPluginSample.iOS/FodyWeavers.xsd
+++ b/samples/src/PopupPluginSample.iOS/FodyWeavers.xsd
@@ -11,6 +11,16 @@
                 <xs:documentation>Used to control if the On_PropertyName_Changed feature is enabled.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
+            <xs:attribute name="TriggerDependentProperties" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to control if the Dependent properties feature is enabled.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="EnableIsChangedProperty" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to control if the IsChanged property feature is enabled.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
             <xs:attribute name="EventInvokerNames" type="xs:string">
               <xs:annotation>
                 <xs:documentation>Used to change the name of the method that fires the notify event. This is a string that accepts multiple values in a comma separated form.</xs:documentation>
@@ -29,6 +39,16 @@
             <xs:attribute name="UseStaticEqualsFromBase" type="xs:boolean">
               <xs:annotation>
                 <xs:documentation>Used to control if equality checks should use the static Equals method resolved from the base class.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="SuppressWarnings" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to turn off build warnings from this weaver.</xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:attribute name="SuppressOnPropertyNameChangedWarning" type="xs:boolean">
+              <xs:annotation>
+                <xs:documentation>Used to turn off build warnings about mismatched On_PropertyName_Changed methods.</xs:documentation>
               </xs:annotation>
             </xs:attribute>
           </xs:complexType>

--- a/samples/src/PopupPluginSample/App.xaml.cs
+++ b/samples/src/PopupPluginSample/App.xaml.cs
@@ -14,17 +14,6 @@ namespace PopupPluginSample
 {
     public partial class App : PrismApplication
     {
-        /* 
-         * NOTE: 
-         * The Xamarin Forms XAML Previewer in Visual Studio uses System.Activator.CreateInstance.
-         * This imposes a limitation in which the App class must have a default constructor. 
-         * App(IPlatformInitializer initializer = null) cannot be handled by the Activator.
-         */
-        public App()
-            : this(null)
-        {
-        }
-
         public App(IPlatformInitializer initializer)
             : base(initializer)
         {
@@ -54,6 +43,7 @@ namespace PopupPluginSample
             containerRegistry.RegisterForNavigation<ViewA>();
             containerRegistry.RegisterForNavigation<ViewB>();
 
+            containerRegistry.RegisterDialog<DismissableDialog, SampleDialogViewModel>();
             containerRegistry.RegisterDialog<SampleDialog, SampleDialogViewModel>();
             containerRegistry.RegisterDialog<NotAnimatedDialog, SampleDialogViewModel>();
         }

--- a/samples/src/PopupPluginSample/Dialogs/DismissableDialog.xaml
+++ b/samples/src/PopupPluginSample/Dialogs/DismissableDialog.xaml
@@ -3,7 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:prism="http://prismlibrary.com"
              prism:DialogLayout.CloseOnBackgroundTapped="True"
-             prism:DialogLayout.RelativeWidthRequest="0.8"
+             prism:DialogLayout.LayoutBounds="0.5, 0, -1, -1"
+             prism:DialogLayout.UseMask="False"
              BackgroundColor="White"
              Padding="15,20"
              x:Class="PopupPluginSample.Dialogs.DismissableDialog">

--- a/samples/src/PopupPluginSample/Dialogs/DismissableDialog.xaml
+++ b/samples/src/PopupPluginSample/Dialogs/DismissableDialog.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:prism="http://prismlibrary.com"
+             prism:DialogLayout.CloseOnBackgroundTapped="True"
+             prism:DialogLayout.RelativeWidthRequest="0.8"
+             BackgroundColor="White"
+             Padding="15,20"
+             x:Class="PopupPluginSample.Dialogs.DismissableDialog">
+  <StackLayout>
+    <Label Text="Dismissable Dialog"
+           FontSize="Title"
+           HorizontalTextAlignment="Center"
+           FontAttributes="Bold"
+           Margin="0,10"/>
+    <Label Text="This is a sample dialog. Click on the shaded area to dismiss the dialog." />
+    <Button Text="Close"
+            Command="{Binding CloseCommand}" />
+  </StackLayout>
+</ContentView>

--- a/samples/src/PopupPluginSample/Dialogs/DismissableDialog.xaml.cs
+++ b/samples/src/PopupPluginSample/Dialogs/DismissableDialog.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace PopupPluginSample.Dialogs
+{
+    public partial class DismissableDialog
+    {
+        public DismissableDialog()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/samples/src/PopupPluginSample/Views/MenuPage.xaml
+++ b/samples/src/PopupPluginSample/Views/MenuPage.xaml
@@ -19,6 +19,7 @@
       <Button Text="Navigation Page" Command="{prism:NavigateTo '/NavigationRoot/MainPage'}" />
       <Button Text="Sample Dialog" Command="{prism:ShowDialog SampleDialog}" />
       <Button Text="Dialog (not animated)" Command="{prism:ShowDialog NotAnimatedDialog}" />
+      <Button Text="Dismissable Dialog" Command="{prism:ShowDialog DismissableDialog}" />
       <Button Text="ViewA" Command="{prism:NavigateTo ViewA}" />
       <!--        <Button Text="Content Page" Command="NavigateCommand" CommandParameter="MainPage" />-->
     </StackLayout>

--- a/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
@@ -209,6 +209,12 @@ namespace Prism.Services.Dialogs.Popups
         private async void PushPopupPage(PopupPage popupPage, View dialogView, Action<IDialogParameters> closeCallback, bool animated = true)
         {
             View mask = DialogLayout.GetMask(dialogView);
+            var gesture = new TapGestureRecognizer
+            {
+                NumberOfTapsRequired = 1,
+                Command = new Command<IDialogParameters>(closeCallback),
+                CommandParameter = new DialogParameters()
+            };
 
             if (mask is null)
             {
@@ -222,12 +228,7 @@ namespace Prism.Services.Dialogs.Popups
 
             mask.SetBinding(VisualElement.WidthRequestProperty, new Binding { Path = "Width", Source = popupPage });
             mask.SetBinding(VisualElement.HeightRequestProperty, new Binding { Path = "Height", Source = popupPage });
-            mask.GestureRecognizers.Add(new TapGestureRecognizer
-            {
-                NumberOfTapsRequired = 1,
-                Command = new Command<IDialogParameters>(closeCallback),
-                CommandParameter = new DialogParameters()
-            });
+            mask.GestureRecognizers.Add(gesture);
 
             var overlay = new AbsoluteLayout();
             var relativeWidth = DialogLayout.GetRelativeWidthRequest(dialogView);
@@ -259,6 +260,10 @@ namespace Prism.Services.Dialogs.Popups
             if (DialogLayout.GetUseMask(dialogView) ?? true)
             {
                 overlay.Children.Add(mask);
+            }
+            else
+            {
+                overlay.GestureRecognizers.Add(gesture);
             }
 
             overlay.Children.Add(dialogView);

--- a/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
+++ b/src/Prism.Plugin.Popups/Dialogs/PopupDialogService.cs
@@ -103,7 +103,8 @@ namespace Prism.Services.Dialogs.Popups
                     popupPage.BackgroundClicked += CloseOnBackgroundClicked;
                 }
 
-                PushPopupPage(popupPage, view, animated);
+                Action<IDialogParameters> closeCallback = closeOnBackgroundTapped ? DialogAware_RequestClose : p => { };
+                PushPopupPage(popupPage, view, closeCallback , animated);
             }
             catch (Exception ex)
             {
@@ -205,7 +206,7 @@ namespace Prism.Services.Dialogs.Popups
             }
         }
 
-        private async void PushPopupPage(PopupPage popupPage, View dialogView, bool animated = true)
+        private async void PushPopupPage(PopupPage popupPage, View dialogView, Action<IDialogParameters> closeCallback, bool animated = true)
         {
             View mask = DialogLayout.GetMask(dialogView);
 
@@ -221,6 +222,12 @@ namespace Prism.Services.Dialogs.Popups
 
             mask.SetBinding(VisualElement.WidthRequestProperty, new Binding { Path = "Width", Source = popupPage });
             mask.SetBinding(VisualElement.HeightRequestProperty, new Binding { Path = "Height", Source = popupPage });
+            mask.GestureRecognizers.Add(new TapGestureRecognizer
+            {
+                NumberOfTapsRequired = 1,
+                Command = new Command<IDialogParameters>(closeCallback),
+                CommandParameter = new DialogParameters()
+            });
 
             var overlay = new AbsoluteLayout();
             var relativeWidth = DialogLayout.GetRelativeWidthRequest(dialogView);


### PR DESCRIPTION
# Description

Fixes issue with background tapped not dismissing the dialog. The mask and root Absolute Layout cover the PopupPage background which prevented the dialog from dismissing. This is now resolved by ensuring that the underlying layer contains a gesture recognizer to properly dismiss when tapped.

- closes #148