### PR TITLE
ApplicationLifecycleAware support

### DIFF
--- a/samples/src/PopupPluginSample/App.xaml.cs
+++ b/samples/src/PopupPluginSample/App.xaml.cs
@@ -65,5 +65,15 @@ namespace PopupPluginSample
             public override void Warning(string category, string message) =>
                 Trace.WriteLine($"    {category}: {message}");
         }
+
+        protected override void OnResume()
+        {
+            this.PopupPluginOnResume();
+        }
+
+        protected override void OnSleep()
+        {
+            this.PopupPluginOnSleep();
+        }
     }
 }

--- a/src/Prism.Plugin.Popups/ApplicationLifecycleExtensions.cs
+++ b/src/Prism.Plugin.Popups/ApplicationLifecycleExtensions.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Prism.AppModel;
+using Prism.Common;
+using Prism.Ioc;
+using Rg.Plugins.Popup.Contracts;
+
+namespace Prism.Plugin.Popups
+{
+    /// <summary>
+    /// Provides support extensions for <see cref="IApplicationLifecycleAware" />
+    /// </summary>
+    public static class ApplicationLifecycleExtensions
+    {
+        /// <summary>
+        /// Adds support for <see cref="IApplicationLifecycleAware.OnResume" />
+        /// </summary>
+        /// <remarks>
+        /// Do not invoke <c>base.OnResume()</c>.
+        /// </remarks>
+        /// <param name="app">The <see cref="PrismApplicationBase" /></param>
+        public static void PopupPluginOnResume(this PrismApplicationBase app)
+        {
+            InvokeLifecyleEvent(app, x => x.OnResume());
+        }
+
+        /// <summary>
+        /// Adds support for <see cref="IApplicationLifecycleAware.OnSleep" />
+        /// </summary>
+        /// <remarks>
+        /// Do not invoke <c>base.OnResume()</c>.
+        /// </remarks>
+        /// <param name="app">The <see cref="PrismApplicationBase" /></param>
+        public static void PopupPluginOnSleep(this PrismApplicationBase app)
+        {
+            InvokeLifecyleEvent(app, x => x.OnSleep());
+        }
+
+        private static void InvokeLifecyleEvent(PrismApplicationBase app, Action<IApplicationLifecycleAware> action)
+        {
+            if (app.MainPage != null)
+            {
+                var popupNavigation = app.Container.Resolve<IPopupNavigation>();
+                var appProvider = app.Container.Resolve<IApplicationProvider>();
+
+                var page = PopupUtilities.TopPage(popupNavigation, appProvider);
+                PageUtilities.InvokeViewAndViewModelAction(page, action);
+            }
+        }
+    }
+}

--- a/src/Prism.Plugin.Popups/PopupPlugin.cs
+++ b/src/Prism.Plugin.Popups/PopupPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if MONOANDROID
+using System;
 using System.Threading;
 using Prism.Common;
 using Prism.Ioc;
@@ -13,7 +14,6 @@ namespace Prism.Plugin.Popups
     public static class PopupPlugin
     {
         private static readonly SemaphoreSlim semaphore = new SemaphoreSlim(1);
-#if MONOANDROID
         /// <summary>
         /// Called when the Activity has detected the user's press of the back key
         /// </summary>
@@ -42,6 +42,6 @@ namespace Prism.Plugin.Popups
                 semaphore.Release();
             }
         }
-#endif
     }
 }
+#endif


### PR DESCRIPTION
# Description

Adding support for IApplicationLifecycleAware. This exposes new extension methods for the PrismApplicationBase which replace the base calls to OnResume/OnSleep. If you opt into this you should under no circumstance invoke both the extension method and base call

```cs
public partial class App : PrismApplication
{
    protected override void OnResume()
    {
        this.PopupPluginOnResume();
    }

    protected override void OnSleep()
    {
        this.PopupPluginOnSleep();
    }
}
```

- closes #123