### PR TITLE
Feature/flyout page support

### DIFF
--- a/samples/src/PopupPluginSample/App.xaml.cs
+++ b/samples/src/PopupPluginSample/App.xaml.cs
@@ -38,6 +38,7 @@ namespace PopupPluginSample
             containerRegistry.RegisterForNavigation<NavigationPage>();
             containerRegistry.RegisterForNavigation<MainPage, MainPageViewModel>();
             containerRegistry.RegisterForNavigation<MDPRoot, MDPRootViewModel>();
+            containerRegistry.RegisterForNavigation<FLPRoot, FLPRootViewModel>();
             containerRegistry.RegisterForNavigation<MenuPage, MenuPageViewModel>();
             containerRegistry.RegisterForNavigation<NavigationRoot>();
             containerRegistry.RegisterForNavigation<PopupView, PopupViewModel>();

--- a/samples/src/PopupPluginSample/PopupPluginSample.csproj
+++ b/samples/src/PopupPluginSample/PopupPluginSample.csproj
@@ -16,4 +16,10 @@
     <ProjectReference Include="..\..\..\src\Prism.Plugin.Popups\Prism.Plugin.Popups.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Views\FLPRoot.xaml.cs">
+      <DependentUpon>FLPRoot.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/samples/src/PopupPluginSample/PopupPluginSample.csproj
+++ b/samples/src/PopupPluginSample/PopupPluginSample.csproj
@@ -16,10 +16,4 @@
     <ProjectReference Include="..\..\..\src\Prism.Plugin.Popups\Prism.Plugin.Popups.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Update="Views\FLPRoot.xaml.cs">
-      <DependentUpon>FLPRoot.xaml</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
 </Project>

--- a/samples/src/PopupPluginSample/ViewModels/FLPRootViewModel.cs
+++ b/samples/src/PopupPluginSample/ViewModels/FLPRootViewModel.cs
@@ -1,0 +1,12 @@
+﻿using Prism.Navigation;
+
+namespace PopupPluginSample.ViewModels
+{
+    public class FLPRootViewModel : BaseViewModel
+    {
+        public FLPRootViewModel(INavigationService navigationService)
+            : base(navigationService)
+        {
+        }
+    }
+}

--- a/samples/src/PopupPluginSample/Views/FLPRoot.xaml
+++ b/samples/src/PopupPluginSample/Views/FLPRoot.xaml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FlyoutPage xmlns="http://xamarin.com/schemas/2014/forms" 
+                  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                  xmlns:prism="http://prismlibrary.com"
+                  xmlns:local="clr-namespace:PopupPluginSample.Xaml"
+                  x:Class="PopupPluginSample.Views.FLPRoot">
+
+  <FlyoutPage.Flyout>
+    <ContentPage Title="Menu">
+      <Grid>
+        <Grid.RowDefinitions>
+          <RowDefinition Height="1*" />
+          <RowDefinition Height="2*" />
+        </Grid.RowDefinitions>
+
+        <BoxView Color="LightCoral"
+                 HorizontalOptions="FillAndExpand"
+                 VerticalOptions="FillAndExpand" />
+        <Label Text="A Menu" 
+               TextColor="White"
+               HorizontalOptions="CenterAndExpand"
+               VerticalOptions="CenterAndExpand"
+               Grid.Row="0" />
+
+        <StackLayout Padding="40"
+                             Grid.Row="1">
+          <Label Text="You might have menu options here" Grid.Row="1" />
+          <Button Text="Launch Popup (XAML)" 
+                  Command="{local:DebugNavigateTo PopupView}" />
+          <Button Text="Launch Popup (Classic)"
+                  Command="{Binding NavigateCommand}"
+                  CommandParameter="PopupView" />
+          <Button Text="Sample Dialog"
+            Command="{prism:ShowDialog SampleDialog}" />
+          <Button Text="Back to Menu" 
+                  Command="{prism:NavigateTo '/MenuPage'}" />
+        </StackLayout>
+      </Grid>
+    </ContentPage>
+  </FlyoutPage.Flyout>
+
+</FlyoutPage>

--- a/samples/src/PopupPluginSample/Views/FLPRoot.xaml.cs
+++ b/samples/src/PopupPluginSample/Views/FLPRoot.xaml.cs
@@ -1,0 +1,15 @@
+﻿using Prism.Navigation;
+using Xamarin.Forms;
+
+namespace PopupPluginSample.Views
+{
+    public partial class FLPRoot : FlyoutPage, IMasterDetailPageOptions
+    {
+        public FLPRoot()
+        {
+            InitializeComponent();
+        }
+
+        public bool IsPresentedAfterNavigation => Device.Idiom != TargetIdiom.Phone;
+    }
+}

--- a/samples/src/PopupPluginSample/Views/FLPRoot.xaml.cs
+++ b/samples/src/PopupPluginSample/Views/FLPRoot.xaml.cs
@@ -3,7 +3,7 @@ using Xamarin.Forms;
 
 namespace PopupPluginSample.Views
 {
-    public partial class FLPRoot : FlyoutPage, IMasterDetailPageOptions
+    public partial class FLPRoot : FlyoutPage, IFlyoutPageOptions
     {
         public FLPRoot()
         {

--- a/samples/src/PopupPluginSample/Views/MenuPage.xaml
+++ b/samples/src/PopupPluginSample/Views/MenuPage.xaml
@@ -15,6 +15,7 @@
                  VerticalOptions="Center">
       <Label Text="Select the root page to test from" />
       <Button Text="Master Detail Page" Command="{prism:NavigateTo '/MDPRoot/NavigationRoot/MainPage'}" />
+      <Button Text="Flyout Page" Command="{prism:NavigateTo '/FLPRoot/NavigationRoot/MainPage'}" />
       <Button Text="Tabbed Page" Command="{prism:NavigateTo '/TabbedRoot'}" />
       <Button Text="Navigation Page" Command="{prism:NavigateTo '/NavigationRoot/MainPage'}" />
       <Button Text="Sample Dialog" Command="{prism:ShowDialog SampleDialog}" />

--- a/src/Prism.Plugin.Popups/Extensions/PageExtensions.cs
+++ b/src/Prism.Plugin.Popups/Extensions/PageExtensions.cs
@@ -26,6 +26,7 @@ namespace Prism.Plugin.Popups.Extensions
         public static Page GetDisplayedPage(this Page page)
         {
             while (page.IsOrDerivesFrom<MasterDetailPage>() ||
+                   page.IsOrDerivesFrom<FlyoutPage>() ||
                   page.IsOrDerivesFrom<TabbedPage>() ||
                   page.IsOrDerivesFrom<NavigationPage>())
             {
@@ -33,6 +34,9 @@ namespace Prism.Plugin.Popups.Extensions
                 {
                     case MasterDetailPage mdp:
                         page = mdp.Detail;
+                        break;
+                    case FlyoutPage flp:
+                        page = flp.Detail;
                         break;
                     case TabbedPage tabbed:
                         page = tabbed.CurrentPage;

--- a/src/Prism.Plugin.Popups/Extensions/PageExtensions.cs
+++ b/src/Prism.Plugin.Popups/Extensions/PageExtensions.cs
@@ -25,16 +25,12 @@ namespace Prism.Plugin.Popups.Extensions
         /// <returns>The displayed page.</returns>
         public static Page GetDisplayedPage(this Page page)
         {
-            while (page.IsOrDerivesFrom<MasterDetailPage>() ||
-                   page.IsOrDerivesFrom<FlyoutPage>() ||
+            while (page.IsOrDerivesFrom<FlyoutPage>() ||
                   page.IsOrDerivesFrom<TabbedPage>() ||
                   page.IsOrDerivesFrom<NavigationPage>())
             {
                 switch (page)
                 {
-                    case MasterDetailPage mdp:
-                        page = mdp.Detail;
-                        break;
                     case FlyoutPage flp:
                         page = flp.Detail;
                         break;


### PR DESCRIPTION

### Description
Suppose we have Flyout page as a app root page and detail page is a navigation page let's say page A. Now we tap on button in the page A and show some pop-up. When we close the pop-up screen we should navigate back to the page A with navigation parameters. That means `OnNavigatedTo`  method should be invoked with navigation parameters in the page A's view model. The problem was that `OnNavigatedTo` method wasn't invoked in the details page's view model. Instead it was invoked in the root flyout page's view model. The reason was just missing check in the page extensions

### Solution

1. Added missing flyout check in the page extensions
2. Added flyout page in the sample app